### PR TITLE
Ubuntu13.10

### DIFF
--- a/app/css/app.css
+++ b/app/css/app.css
@@ -78,6 +78,8 @@ drop-down-check-box button {
   max-width: 100px;
   max-height: 30px;
   overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 drop-down-check-box input[type="checkbox"] {
   display: inline-block;

--- a/app/data/platforms.json
+++ b/app/data/platforms.json
@@ -8,8 +8,8 @@
   {"name": "Ubuntu", "labels": "linux ubuntu", "platform": "linux", "added": false, "versions":[
     {"name": "12.04 (32bit)", "labels": "12.04 32bit", "added": false},
     {"name": "12.04 (64bit)", "labels": "12.04 64bit", "platform": "linux64", "added": false},
-    {"name": "13.04 (32bit)", "labels": "13.04 32bit", "added": false},
-    {"name": "13.04 (64bit)", "labels": "13.04 64bit", "platform": "linux64", "added": false}
+    {"name": "13.10 (32bit)", "labels": "13.10 32bit", "added": false},
+    {"name": "13.10 (64bit)", "labels": "13.10 64bit", "platform": "linux64", "added": false}
   ]},
   {"name": "Windows", "labels": "windows", "platform": "win32", "added": false, "versions":[
     {"name": "XP", "labels": "xp 32bit", "added": false},


### PR DESCRIPTION
This is a pr for issue #9 depends on issue #8
I chenged [Ubuntu 13.04] to [Ubuntu 13.10], and use ellipsis when display locales inside locales button.
I can see [windows 8.1 32bit] in the application, so I don't think it is missing.
