### PR TITLE
Don't rely on candidates builds when adding release options (#13)

### DIFF
--- a/app/js/directives/directives.js
+++ b/app/js/directives/directives.js
@@ -14,7 +14,7 @@ mciconf.directive('build', function () {
         var build = {};
         build.exists = STATE.NOT_CHECKED;
         build.name = ($rootScope.firefoxVersions.length) ? $rootScope.firefoxVersions[0] : "";
-        build.type = $rootScope.firefoxVersionsTypes[0];
+        build.type = $rootScope.firefoxReleaseType[build.name];
         build.locale = "";
         build.availableLocales = [];
         $rootScope.builds[aIndex].firefoxVersions.push(build);
@@ -219,18 +219,20 @@ mciconf.directive('build', function () {
        * @param aBuildIndex
        */
       $scope.versionChanged = function (aVersionIndex, aBuildIndex) {
-        var indexOfVersion = $rootScope.firefoxVersions. indexOf($rootScope.builds[aBuildIndex].
-                                                                            firefoxVersions[aVersionIndex].
-                                                                            name);
-        var isRelease = $rootScope.firefoxVersionsTypes[indexOfVersion];
+        $rootScope.builds[aBuildIndex].firefoxVersions[aVersionIndex].buildNumbers = ["final"];
+        var version = $rootScope.builds[aBuildIndex].firefoxVersions[aVersionIndex].name;
+        var releaseType = $rootScope.firefoxReleaseType[version];
 
-        // If the build has a release version we will set it as default in build numbers array
-        $rootScope.builds[aBuildIndex].
-                   firefoxVersions[aVersionIndex].
-                   buildNumbers = (isRelease) ? ['final'] : [];
-        var versionName = $rootScope.builds[aBuildIndex].
-                                 firefoxVersions[aVersionIndex].
-                                 name + "-candidates/";
+        // If the current version is under release directory no build number
+        // checks are necessary
+        if (releaseType === "release") {
+          $rootScope.builds[aBuildIndex].firefoxVersions[aVersionIndex].buildNumber = "final";
+          $scope.buildNumberChanged(aVersionIndex, aBuildIndex);
+
+          return;
+        }
+
+        var versionName = version + "-candidates/";
         var address = "http://ftp.mozilla.org/pub/mozilla.org/firefox/candidates/" + versionName;
 
         $rootScope.parseAtAddress(address, 'a', function () {
@@ -534,7 +536,7 @@ mciconf.directive('configPicker', function () {
                   var name = $rootScope.firefoxVersions[$rootScope.firefoxVersions.indexOf(version.split("#")[0])];
                   if (!name)
                     $scope.$emit('notify', {type: 'error',
-                                            message: 'Build ' + version + ' dose not exists'});
+                                            message: 'Build ' + version + ' does not exists'});
 
                   var v = {};
                   v.exists = (!name) ? STATE.NOT_FOUND : STATE.NOT_CHECKED;


### PR DESCRIPTION
On issue #13 the build version of 26.0b1 and 25.0b1 were under the archived directory, a directory that I didn't parsed. I added that, and I moved the later code in the postHook callback.
